### PR TITLE
Fix truncated header value

### DIFF
--- a/src/adapters/http-multipart-mixed-boundary-adapter.ts
+++ b/src/adapters/http-multipart-mixed-boundary-adapter.ts
@@ -120,7 +120,7 @@ export class HttpMultipartMixedBoundaryAdapter implements IBatchHttpRequestAdapt
               status = parseInt(lineParts[1], 10);
               statusText = lineParts.slice(2).join(HttpMultipartMixedBoundaryAdapter.SPACE);
             } else {
-              headers.append(lineParts[0].replace(":", HttpMultipartMixedBoundaryAdapter.EMPTY_STRING), lineParts[1]);
+              headers.append(lineParts[0].replace(":", HttpMultipartMixedBoundaryAdapter.EMPTY_STRING), header.substring(header.indexOf(HttpMultipartMixedBoundaryAdapter.SPACE)+1));
             }
           });
 


### PR DESCRIPTION
In case of ranged request, the response headers looks like this:

--34a80522-fb29-4887-ab36-6d20ac045936
Content-Type: application/http; msgtype=response

HTTP/1.1 206 Partial Content
Accept-Ranges: Item
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Content-Range
Content-Type: application/json; charset=utf-8
Content-Range: Item 0-19/56

The current code just split for ' ' (space) and take the only first part of the value (here "Item" instead of "Item 0-19/56").
The fix just take the rest (not the headers name) of the line.